### PR TITLE
fix for feed sort not working

### DIFF
--- a/src/resolvers/Feed.js
+++ b/src/resolvers/Feed.js
@@ -1,5 +1,9 @@
 function links(parent, args, context, info) {
-  return context.db.query.links({ where: { id_in: parent.linkIds } }, info)
+  const params = { where: { id_in: parent.linkIds }};
+  if (parent.orderBy) {
+      params['orderBy'] = parent.orderBy;
+  }
+  return context.db.query.links(params, info);
 }
 
 module.exports = {

--- a/src/resolvers/Query.js
+++ b/src/resolvers/Query.js
@@ -25,6 +25,7 @@ async function feed(parent, args, context, info) {
   return {
     count: linksConnection.aggregate.count,
     linkIds: queriedLinkes.map(link => link.id),
+    orderBy: args.orderBy
   }
 }
 


### PR DESCRIPTION
When I ran the feed query with orderBy, the sort didn't seem to be working. Example:

```
query {
  feed(orderBy: description_DESC) {
    links {
      id,
      url,
      description
    }
  }
}
```

The results were not sorted (same result testing orderBy on fields as well). 

It seems that in Feed.js, when parent link ids are queried, the resulting link order gets scrambled (even if they might've been sorted in the original query from Query.js) . My fix was to pass the orderBy param into Feed.js. You may have a better solution. Thanks.