### PR TITLE
Send empty Options object to `start` method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -27,4 +27,4 @@ const server = new GraphQLServer({
     }),
   }),
 })
-server.start(() => console.log(`Server is running on http://localhost:4000`))
+server.start({}, () => console.log(`Server is running on http://localhost:4000`))


### PR DESCRIPTION
If the callback is sent first, the playground doesn't load correctly.

Instead it just gives this error:
```
(index):536 Uncaught ReferenceError: GraphQLPlayground is not defined
    at (index):536
```