### PR TITLE
Fixed count when skip is passed.

### DIFF
--- a/src/resolvers/Query.js
+++ b/src/resolvers/Query.js
@@ -7,6 +7,7 @@ async function feed(parent, args, context) {
           { url_contains: args.filter },
         ],
       },
+      skip: args.skip,
     })
     .aggregate()
     .count()


### PR DESCRIPTION
When skip parameter is passed to the query, the counter returns all the items in the database instead of the items specified in the criteria.